### PR TITLE
Clicking on a marker with duplicate items

### DIFF
--- a/app/js/map.coffee
+++ b/app/js/map.coffee
@@ -3,6 +3,7 @@ window.App ||= {}
 App.google =
   map: null
   infoWindow: null
+  lowZIndex: 0
 
 class App.List
   constructor: (items = []) ->
@@ -55,6 +56,7 @@ class App.Marker
       position: position
 
     @marker.addListener 'click', =>
+      @marker.setZIndex(App.google.lowZIndex--)
       App.google.infoWindow.setContent(infoWindowContentCreator())
       App.google.infoWindow.open(App.google.map, @marker)
 

--- a/config/server.coffee
+++ b/config/server.coffee
@@ -3,6 +3,8 @@ module.exports = drawRoutes: (app) ->
   app.get '/api/work-orders', (req, res) ->
     res.json workOrders: [
       { id: 1, description: "Cbus10", address: "10 W Broad ST", city: "Columbus", state: "OH", lat: 39.9625079, lng: -83.00121009999998},
+      { id: 4, description: "Cbus10 #2", address: "10 W Broad ST", city: "Columbus", state: "OH", lat: 39.9625079, lng: -83.00121009999998},
+      { id: 5, description: "Cbus10 #3", address: "10 W Broad ST", city: "Columbus", state: "OH", lat: 39.9625079, lng: -83.00121009999998},
       { id: 2, description: "Easton", address: "160 Easton Town Center", city: "Columbus", state: "OH", lat: 40.04985670000001, lng: -82.9156888}
       { id: 3, description: "Starbucks", address: "6470 Sawmill Rd", city: "Columbus", state: "OH", lat: 40.1005337, lng: -83.09104589999998}
     ]


### PR DESCRIPTION
Effectively pushes the marker back when you click it.
You still get the info window, but if you click the marker
again you'll be getting the next one. Default behavior is
that the marker on top stays on top no matter what the user
does.

Fixes #1
